### PR TITLE
Edge to edge

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,7 +78,6 @@ dependencies {
     debugImplementation(libs.uiTooling)
     implementation(libs.uiToolingPreview)
     implementation(libs.material3)
-    implementation(libs.accompanistSystemUiController)
     implementation(libs.activityCompose)
     implementation(libs.lifecycleViewModelCompose)
     implementation(libs.firebaseFunctions)

--- a/app/src/main/java/bg/zahov/app/MainActivity.kt
+++ b/app/src/main/java/bg/zahov/app/MainActivity.kt
@@ -2,6 +2,7 @@ package bg.zahov.app
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -16,6 +17,7 @@ class MainActivity : AppCompatActivity() {
     private val loadingViewModel: LoadingViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
         splashScreen.setKeepOnScreenCondition {

--- a/app/src/main/java/bg/zahov/app/MainActivity.kt
+++ b/app/src/main/java/bg/zahov/app/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import bg.zahov.app.Inject.serviceErrorHandler
 import bg.zahov.app.data.model.ServiceState
@@ -20,6 +21,7 @@ class MainActivity : AppCompatActivity() {
         enableEdgeToEdge()
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
+
         splashScreen.setKeepOnScreenCondition {
             loadingViewModel.loading.value
         }

--- a/app/src/main/java/bg/zahov/app/ui/theme/Theme.kt
+++ b/app/src/main/java/bg/zahov/app/ui/theme/Theme.kt
@@ -1,18 +1,21 @@
 package bg.zahov.app.ui.theme
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 
 private val lightScheme = lightColorScheme(
     primary = primaryLight,
@@ -271,12 +274,14 @@ fun FitnessTheme(
         else -> lightScheme
     }
 
-    val systemUiController = rememberSystemUiController()
-
-    systemUiController.setStatusBarColor(
-        color = colorScheme.background,
-        darkIcons = darkTheme
-    )
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            WindowCompat.getInsetsController(window, view)
+                .isAppearanceLightStatusBars = !darkTheme
+        }
+    }
 
     MaterialTheme(
         colorScheme = colorScheme,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ googleServicesPlugin = "4.4.2"
 androidxTestExtJunit = "1.1.5"
 androidxTestRunner = "1.5.0"
 material = "1.12.0"
-accompanistSystemUiController = "0.30.1"
 splashscreenVer = "1.0.1"
 
 [libraries]
@@ -51,7 +50,6 @@ junit = { module = "junit:junit", version.ref = "junit" }
 espressoCore = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 androidxTestExtJunit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExtJunit" }
 androidxTestRunner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
-accompanistSystemUiController = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanistSystemUiController" }
 
 firebaseFunctions = { module = "com.google.firebase:firebase-functions-ktx", version.ref = "firebaseFunctions" }
 firebaseAuth = { module = "com.google.firebase:firebase-auth-ktx", version.ref = "firebaseAuth" }


### PR DESCRIPTION
Enabled Edge to Edge for version < 35
Also added a fix for Status Bar Icons' color so they don't merge with the background

Manual testing  was done by clicking throughout different screens. Additionally pulled the status bar to check for irregularities and switching between landscape and portrait (including closing and half-closing the flip phone)

Pixel Fold Api 35 - Dark mode , portrait , half-closed
![flip phone api 35](https://github.com/user-attachments/assets/f177c6d2-2d87-4ce8-9633-566738acda3b)

Pixel 7a  Api 30 - Light mode , landscape
Old:
![30 flip](https://github.com/user-attachments/assets/438828a4-963d-488a-85ee-c8ba1be5eb0f)

New: 
![light flipped api 30](https://github.com/user-attachments/assets/611bb6c1-83d1-4d28-a454-7936c703bd36)

Tablet Api 26 - Light mode , portrait
Old:
![table 2](https://github.com/user-attachments/assets/69d0ef51-1406-4894-ac2b-32eaa51c5254)

New:
![table api 26](https://github.com/user-attachments/assets/5d1bd261-4a16-4934-be47-2983643edb48)

