### PR TITLE
Migrate auth to coroutine extensions

### DIFF
--- a/app/src/main/java/bg/zahov/app/LoadingViewModel.kt
+++ b/app/src/main/java/bg/zahov/app/LoadingViewModel.kt
@@ -38,6 +38,7 @@ class LoadingViewModel(
                 userProvider.authStateFlow().collect { isAuthenticated ->
                     if (isAuthenticated) {
                         _loading.value = true
+                        userProvider.initDataSources()
                         _navigationTarget.update { Home }
                     } else {
                         _navigationTarget.update { Welcome }

--- a/app/src/main/java/bg/zahov/app/LoadingViewModel.kt
+++ b/app/src/main/java/bg/zahov/app/LoadingViewModel.kt
@@ -6,7 +6,6 @@ import bg.zahov.app.data.interfaces.ServiceErrorHandler
 import bg.zahov.app.data.interfaces.UserProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -24,7 +23,7 @@ import kotlinx.coroutines.launch
  */
 class LoadingViewModel(
     private val userProvider: UserProvider = Inject.userProvider,
-    private val serviceError: ServiceErrorHandler = Inject.serviceErrorHandler
+    private val serviceError: ServiceErrorHandler = Inject.serviceErrorHandler,
 ) : ViewModel() {
     private val _loading = MutableStateFlow(true)
     val loading: StateFlow<Boolean> = _loading
@@ -39,8 +38,6 @@ class LoadingViewModel(
                 userProvider.authStateFlow().collect { isAuthenticated ->
                     if (isAuthenticated) {
                         _loading.value = true
-                        userProvider.initDataSources()
-                        userProvider.getUser().first()
                         _navigationTarget.update { Home }
                     } else {
                         _navigationTarget.update { Welcome }

--- a/app/src/main/java/bg/zahov/app/MainNavGraph.kt
+++ b/app/src/main/java/bg/zahov/app/MainNavGraph.kt
@@ -31,11 +31,17 @@ import bg.zahov.app.ui.workout.start.StartWorkoutScreen
 fun MainNavGraph(
     modifier: Modifier = Modifier,
     navController: NavHostController,
-    loadingViewModel: LoadingViewModel = viewModel()
+    loadingViewModel: LoadingViewModel = viewModel(),
 ) {
     LaunchedEffect(Unit) {
         loadingViewModel.navigationTarget.collect {
-            navController.navigate(it)
+            navController.navigate(it) {
+                popUpTo(navController.graph.findStartDestination().id) {
+                    saveState = true
+                }
+                launchSingleTop = true
+                restoreState = true
+            }
         }
     }
 

--- a/app/src/main/java/bg/zahov/app/data/interfaces/Authentication.kt
+++ b/app/src/main/java/bg/zahov/app/data/interfaces/Authentication.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.flow.Flow
 
 
 interface Authentication {
-    suspend fun signup(email: String, password: String) : Task<AuthResult>
-    suspend fun login(email: String, password: String) : Task<AuthResult>
+    suspend fun signup(email: String, password: String)
+    suspend fun login(email: String, password: String)
     suspend fun logout()
     suspend fun deleteAccount()
     suspend fun passwordResetByEmail(email: String): Task<Void>

--- a/app/src/main/java/bg/zahov/app/data/interfaces/Authentication.kt
+++ b/app/src/main/java/bg/zahov/app/data/interfaces/Authentication.kt
@@ -1,21 +1,25 @@
 package bg.zahov.app.data.interfaces
 
 import com.google.android.gms.tasks.Task
-import com.google.firebase.auth.AuthResult
 import kotlinx.coroutines.flow.Flow
 
 
 interface Authentication {
-    suspend fun signup(email: String, password: String)
-    suspend fun login(email: String, password: String)
+    suspend fun signup(email: String, password: String): AuthResponse
+    suspend fun login(email: String, password: String): AuthResponse
     suspend fun logout()
     suspend fun deleteAccount()
     suspend fun passwordResetByEmail(email: String): Task<Void>
     suspend fun passwordResetForLoggedUser(): Task<Void>
-    fun authStateFlow() : Flow<Boolean>
+    fun authStateFlow(): Flow<Boolean>
     suspend fun initDataSources()
     suspend fun createDataSources(username: String, userId: String)
     suspend fun updatePassword(newPassword: String): Task<Void>
     suspend fun reauthenticate(password: String): Task<Void>
     suspend fun getEmail(): String
+}
+
+sealed interface AuthResponse {
+    data class Success(val userId: String) : AuthResponse
+    data class Failure(val error: Throwable) : AuthResponse
 }

--- a/app/src/main/java/bg/zahov/app/data/interfaces/UserProvider.kt
+++ b/app/src/main/java/bg/zahov/app/data/interfaces/UserProvider.kt
@@ -2,14 +2,13 @@ package bg.zahov.app.data.interfaces
 
 import bg.zahov.app.data.model.User
 import com.google.android.gms.tasks.Task
-import com.google.firebase.auth.AuthResult
 import kotlinx.coroutines.flow.Flow
 
 interface UserProvider {
     suspend fun getUser(): Flow<User>
     suspend fun changeUserName(newUsername: String): Task<Void>
-    suspend fun signup(email: String, password: String): AuthResult
-    suspend fun login(email: String, password: String): Task<AuthResult>
+    suspend fun signup(email: String, password: String)
+    suspend fun login(email: String, password: String)
     suspend fun logout()
     suspend fun deleteAccount()
     suspend fun passwordResetByEmail(email: String): Task<Void>

--- a/app/src/main/java/bg/zahov/app/data/interfaces/UserProvider.kt
+++ b/app/src/main/java/bg/zahov/app/data/interfaces/UserProvider.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.flow.Flow
 interface UserProvider {
     suspend fun getUser(): Flow<User>
     suspend fun changeUserName(newUsername: String): Task<Void>
-    suspend fun signup(email: String, password: String)
-    suspend fun login(email: String, password: String)
+    suspend fun signup(email: String, password: String): AuthResponse
+    suspend fun login(email: String, password: String): AuthResponse
     suspend fun logout()
     suspend fun deleteAccount()
     suspend fun passwordResetByEmail(email: String): Task<Void>

--- a/app/src/main/java/bg/zahov/app/data/provider/UserProviderImpl.kt
+++ b/app/src/main/java/bg/zahov/app/data/provider/UserProviderImpl.kt
@@ -9,12 +9,8 @@ import kotlinx.coroutines.flow.Flow
 
 class UserProviderImpl : UserProvider {
     companion object {
-        @Volatile
         private var instance: UserProviderImpl? = null
-        fun getInstance() =
-            instance ?: synchronized(this) {
-                instance ?: UserProviderImpl().also { instance = it }
-            }
+        fun getInstance() = instance ?: UserProviderImpl().also { instance = it }
     }
 
     private val userRepo = UserRepositoryImpl.getInstance()

--- a/app/src/main/java/bg/zahov/app/data/provider/UserProviderImpl.kt
+++ b/app/src/main/java/bg/zahov/app/data/provider/UserProviderImpl.kt
@@ -5,9 +5,7 @@ import bg.zahov.app.data.model.User
 import bg.zahov.app.data.repository.AuthenticationImpl
 import bg.zahov.app.data.repository.UserRepositoryImpl
 import com.google.android.gms.tasks.Task
-import com.google.firebase.auth.AuthResult
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.tasks.await
 
 class UserProviderImpl : UserProvider {
     companion object {
@@ -26,12 +24,9 @@ class UserProviderImpl : UserProvider {
 
     override suspend fun changeUserName(newUsername: String) = userRepo.changeUserName(newUsername)
 
-    override suspend fun signup(
-        email: String, password: String,
-    ): AuthResult = auth.signup(email, password).await()
+    override suspend fun signup(email: String, password: String) = auth.signup(email, password)
 
-    override suspend fun login(email: String, password: String): Task<AuthResult> =
-        auth.login(email, password)
+    override suspend fun login(email: String, password: String) = auth.login(email, password)
 
     override suspend fun logout() = auth.logout()
 

--- a/app/src/main/java/bg/zahov/app/data/remote/FirebaseAuth.kt
+++ b/app/src/main/java/bg/zahov/app/data/remote/FirebaseAuth.kt
@@ -78,7 +78,6 @@ class FirebaseAuthentication {
 
     private fun init() {
         auth.currentUser?.uid?.let {
-            Log.d("init", "init")
             firestore.initUser(it)
         }
     }

--- a/app/src/main/java/bg/zahov/app/data/remote/FirestoreManager.kt
+++ b/app/src/main/java/bg/zahov/app/data/remote/FirestoreManager.kt
@@ -1,6 +1,5 @@
 package bg.zahov.app.data.remote
 
-import bg.zahov.app.data.exception.CriticalDataNullException
 import bg.zahov.app.data.model.Exercise
 import bg.zahov.app.data.model.FirestoreFields
 import bg.zahov.app.data.model.Measurement
@@ -8,7 +7,6 @@ import bg.zahov.app.data.model.MeasurementType
 import bg.zahov.app.data.model.Measurements
 import bg.zahov.app.data.model.User
 import bg.zahov.app.data.model.Workout
-import bg.zahov.app.util.generateRandomId
 import bg.zahov.app.util.toFirestoreMap
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference

--- a/app/src/main/java/bg/zahov/app/data/repository/AuthenticationImpl.kt
+++ b/app/src/main/java/bg/zahov/app/data/repository/AuthenticationImpl.kt
@@ -1,23 +1,44 @@
 package bg.zahov.app.data.repository
 
+import bg.zahov.app.data.interfaces.AuthResponse
 import bg.zahov.app.data.interfaces.Authentication
 import bg.zahov.app.data.remote.FirebaseAuthentication
+import com.google.firebase.auth.AuthResult
+import kotlinx.coroutines.CancellationException
 
 class AuthenticationImpl : Authentication {
     companion object {
-        @Volatile
         private var instance: AuthenticationImpl? = null
-        fun getInstance() =
-            instance ?: synchronized(this) {
-                instance ?: AuthenticationImpl().also { instance = it }
-            }
+        fun getInstance() = instance ?: AuthenticationImpl().also { instance = it }
     }
 
     private val auth = FirebaseAuthentication.getInstance()
 
-    override suspend fun login(email: String, password: String) = auth.login(email, password)
+    /**
+     * Authenticates a user with the given email and password.
+     * Maps the result to a standardized AuthResponse format.
+     * @param email User's email.
+     * @param password User's password.
+     * @return [AuthResponse] indicating success or failure.
+     *
+     * @see [AuthResponseMapper]
+     */
+    override suspend fun login(email: String, password: String): AuthResponse =
+        AuthResponseMapper.map(auth.login(email, password))
+            .also { (it as? AuthResponse.Success)?.let { uid -> auth.initFirestoreUser() } }
 
-    override suspend fun signup(email: String, password: String) = auth.signup(email, password)
+    /**
+     * Registers a new user with the given email and password.
+     * Maps the result to a standardized AuthResponse format.
+     * @param email User's email.
+     * @param password User's password.
+     * @return [AuthResponse] indicating success or failure.
+     *
+     *@see [AuthResponseMapper]
+     */
+    override suspend fun signup(email: String, password: String): AuthResponse =
+        AuthResponseMapper.map(auth.signup(email, password))
+            .also { (it as? AuthResponse.Success)?.let { uid -> auth.initFirestoreUser() } }
 
     override suspend fun logout() = auth.logout()
 
@@ -29,7 +50,9 @@ class AuthenticationImpl : Authentication {
 
     override fun authStateFlow() = auth.getAuthStateFlow()
 
-    override suspend fun initDataSources() { /* TODO() */ }
+    override suspend fun initDataSources() {
+        auth.initFirestoreUser()
+    }
 
     override suspend fun createDataSources(username: String, userId: String) =
         auth.create(username, userId)
@@ -39,4 +62,29 @@ class AuthenticationImpl : Authentication {
     override suspend fun reauthenticate(password: String) = auth.reauthenticate(password)
 
     override suspend fun getEmail(): String = auth.getEmail()
+}
+
+/**
+ * Maps authentication results from different sources to a standardized AuthResponse format.
+ */
+object AuthResponseMapper {
+
+    /**
+     * Converts the given authentication result into an AuthResponse.
+     * @param result The authentication result, which could be from Firebase or another service.
+     * @return [AuthResponse.Success] or [AuthResponse.Failure] respectfully
+     */
+    fun <T> map(result: T): AuthResponse = when (result) {
+        is AuthResult -> {
+            if (result.user?.uid == null) {
+                AuthResponse.Failure(Exception("Unable to authenticate"))
+            } else {
+                AuthResponse.Success(userId = result.user?.uid ?: "")
+            }
+
+        }
+        else -> {
+            AuthResponse.Failure(Exception("Unable to authenticate"))
+        }
+    }
 }

--- a/app/src/main/java/bg/zahov/app/data/repository/AuthenticationImpl.kt
+++ b/app/src/main/java/bg/zahov/app/data/repository/AuthenticationImpl.kt
@@ -17,13 +17,11 @@ class AuthenticationImpl : Authentication {
 
     override suspend fun login(email: String, password: String) = auth.login(email, password)
 
-    override suspend fun signup(email: String, password: String) =
-        auth.signup(email, password)
+    override suspend fun signup(email: String, password: String) = auth.signup(email, password)
 
     override suspend fun logout() = auth.logout()
 
     override suspend fun deleteAccount() = auth.deleteAccount()
-
 
     override suspend fun passwordResetByEmail(email: String) = auth.passwordResetByEmail(email)
 
@@ -31,8 +29,10 @@ class AuthenticationImpl : Authentication {
 
     override fun authStateFlow() = auth.getAuthStateFlow()
 
-    override suspend fun initDataSources() = auth.init()
-    override suspend fun createDataSources(username: String, userId: String) = auth.create(username, userId)
+    override suspend fun initDataSources() { /* TODO() */ }
+
+    override suspend fun createDataSources(username: String, userId: String) =
+        auth.create(username, userId)
 
     override suspend fun updatePassword(newPassword: String) = auth.updatePassword(newPassword)
 

--- a/app/src/main/java/bg/zahov/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/bg/zahov/app/ui/settings/SettingsScreen.kt
@@ -33,7 +33,7 @@ import bg.zahov.fitness.app.R
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel = viewModel(),
-    navigateEditProfile: () -> Unit
+    navigateEditProfile: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -167,7 +167,7 @@ fun SettingsContent(
     github: @Composable () -> Unit,
     bugReport: @Composable () -> Unit,
     deleteAccount: () -> Unit,
-    logout: () -> Unit
+    logout: () -> Unit,
 ) {
     Column(
         modifier = Modifier


### PR DESCRIPTION
Based on -> [https://trello.com/c/IktrgT9b/24-migrate-firebase-auth-to-coroutines-extensions](url)

As we agreed with @trifonov-i we are not migrating the entire auth system just a part of it to see if it is possible. So what was rewritten was just `login()` and `signup()`. We no longer return a `Task<AuthResult>`. We use `.await()` and simply handle the errors both functions throw in the appropriate places.

It is not necessary to merge this :)