### PR TITLE
Remove action bar

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -5,11 +5,9 @@
         <item name="android:windowBackground">@color/background</item>
     </style>
 
-    <style name="Theme.Fitness_app.Splash" parent="Theme.SplashScreen">
+    <style name="Theme.Fitness_app.Splash" parent="Theme.SplashScreen.Common">
         <item name="windowSplashScreenBackground">@color/background</item>
         <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_logo</item>
         <item name="postSplashScreenTheme">@style/Theme.Fitness_app</item>
-        <item name="android:windowActionBar">false</item>
-        <item name="android:windowNoTitle">true</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.Fitness_app" parent="Theme.MaterialComponents.Light.NoActionBar">
+    <style name="Theme.Fitness_app" parent="Theme.MaterialComponents.NoActionBar">
         <item name="android:statusBarColor">@color/background</item>
         <item name="android:windowBackground">@color/background</item>
     </style>
@@ -9,5 +9,7 @@
         <item name="windowSplashScreenBackground">@color/background</item>
         <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_logo</item>
         <item name="postSplashScreenTheme">@style/Theme.Fitness_app</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowNoTitle">true</item>
     </style>
 </resources>


### PR DESCRIPTION
`Theme.SplashScreen` doesn't remove action bar by default so replaced it with `Theme.SplashScreen.Common` because it has:
- `<item name="android:windowActionBar">false</item>`
- `<item name="android:windowNoTitle">true</item>`

Tested on api 26 and 35