### PR TITLE
Temporary fix for app module

### DIFF
--- a/app/src/main/java/bg/zahov/app/data/di/ApplicationModule.kt
+++ b/app/src/main/java/bg/zahov/app/data/di/ApplicationModule.kt
@@ -8,6 +8,7 @@ import bg.zahov.app.data.interfaces.SettingsProvider
 import bg.zahov.app.data.interfaces.UserProvider
 import bg.zahov.app.data.interfaces.WorkoutActions
 import bg.zahov.app.data.interfaces.WorkoutProvider
+import bg.zahov.app.data.model.WorkoutState
 import bg.zahov.app.data.provider.AddExerciseToWorkoutProvider
 import bg.zahov.app.data.provider.ExercisesTopBarManager
 import bg.zahov.app.data.provider.FilterProvider
@@ -30,59 +31,55 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class ActivityModule {
-
-    @Binds
-    @Singleton
-    abstract fun provideWorkoutStateProvider(workoutStateProvider: WorkoutStateManager): WorkoutActions
-
-    @Binds
-    @Singleton
-    abstract fun provideRestTimerProvider(restProvider: RestTimerProvider): RestProvider
-
-    @Binds
-    @Singleton
-    abstract fun provideServiceErrorHandler(serviceErrorHandler: ServiceErrorHandlerImpl): ServiceErrorHandler
-
-    @Binds
-    @Singleton
-    abstract fun provideExercisesTopAppHandler(exerciseTopBarManager: ExercisesTopBarManager): ExercisesTopBarHandler
-}
-
-@Module
-@InstallIn(SingletonComponent::class)
 object ApplicationModule {
     @Provides
     @Singleton
-    fun provideUserProvider(): UserProvider = UserProviderImpl()
+    fun provideUserProvider(): UserProvider = UserProviderImpl.getInstance()
 
     @Provides
     @Singleton
-    fun provideSettingsProvider(): SettingsProvider = SettingsProviderImpl()
+    fun provideSettingsProvider(): SettingsProvider = SettingsProviderImpl.getInstance()
 
     @Provides
     @Singleton
-    fun provideWorkoutProvider(): WorkoutProvider = WorkoutProviderImpl()
+    fun provideWorkoutProvider(): WorkoutProvider = WorkoutProviderImpl.getInstance()
 
     @Provides
     @Singleton
     fun provideMeasurementProvider(): MeasurementProvider =
-        MeasurementProviderImpl()
+        MeasurementProviderImpl.getInstance()
 
     @Singleton
     fun provideSelectableExerciseProvider(): SelectableExerciseProvider =
-        SelectableExerciseProvider()
+        SelectableExerciseProvider.getInstance()
 
 
     @Singleton
     fun provideReplaceableExerciseProvider(): ReplaceableExerciseProvider =
-        ReplaceableExerciseProvider()
+        ReplaceableExerciseProvider.getInstance()
 
     @Singleton
     fun provideWorkoutAddedExerciseProvider(): AddExerciseToWorkoutProvider =
-        AddExerciseToWorkoutProvider()
+        AddExerciseToWorkoutProvider.getInstance()
 
     @Singleton
     fun provideFilterProvider(): FilterProvider =
-        FilterProvider()
+        FilterProvider.getInstance()
+
+    @Provides
+    @Singleton
+    fun provideWorkoutStateProvider(): WorkoutActions = WorkoutStateManager.getInstance()
+
+    @Provides
+    @Singleton
+    fun provideRestTimerProvider(): RestProvider = RestTimerProvider.getInstance()
+
+    @Provides
+    @Singleton
+    fun provideServiceErrorHandler(): ServiceErrorHandler = ServiceErrorHandlerImpl.getInstance()
+
+    @Provides
+    @Singleton
+    fun provideExercisesTopAppHandler(): ExercisesTopBarHandler =
+        ExercisesTopBarManager.getInstance()
 }


### PR DESCRIPTION
Previously we had an issue with the instances of our provided dependencies because `Inject` provided an instance that was stored in the `companion object` for each object and hilt provided a separate one which made it hard to test. 

**This should be reverted once all view models are migrated and companion objects should be deleted along with the Inject class**

[https://trello.com/c/Fhw7W5u7/80-bug-hilt-and-nonhilt-viewmodel-multiple-instances-of-shared-dependencies](url)