### PR TITLE
Migrate rest timer vm to hilt

### DIFF
--- a/app/src/main/java/bg/zahov/app/ui/workout/rest/RestScreen.kt
+++ b/app/src/main/java/bg/zahov/app/ui/workout/rest/RestScreen.kt
@@ -29,16 +29,15 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import bg.zahov.app.data.model.ToastManager
 import bg.zahov.app.ui.theme.FitnessTheme
 import bg.zahov.fitness.app.R
 import com.chargemap.compose.numberpicker.ListItemPicker
 
-
 @Composable
-fun RestScreen(restViewModel: RestTimerViewModel = viewModel(), navigate: () -> Unit) {
+fun RestScreen(restViewModel: RestTimerViewModel = hiltViewModel(), navigate: () -> Unit) {
     val state by restViewModel.uiState.collectAsStateWithLifecycle()
     val toast by ToastManager.messages.collectAsStateWithLifecycle()
     val context = LocalContext.current

--- a/app/src/main/java/bg/zahov/app/ui/workout/rest/RestTimerViewModel.kt
+++ b/app/src/main/java/bg/zahov/app/ui/workout/rest/RestTimerViewModel.kt
@@ -2,16 +2,16 @@ package bg.zahov.app.ui.workout.rest
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import bg.zahov.app.Inject
 import bg.zahov.app.data.model.RestState
-import bg.zahov.app.data.model.ToastManager
 import bg.zahov.app.data.provider.RestTimerProvider
 import bg.zahov.app.util.parseTimeStringToLong
 import bg.zahov.fitness.app.R
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.lang.IllegalArgumentException
+import javax.inject.Inject
 
 /**
  * A sealed interface that represents the different states of a rest timer.
@@ -86,9 +86,9 @@ object RestInfo {
  * such as starting, pausing, and tracking progress.
  *
  **/
-class RestTimerViewModel(
-    private val restManager: RestTimerProvider = Inject.restTimerProvider,
-    private val toastManager: ToastManager = ToastManager,
+@HiltViewModel
+class RestTimerViewModel @Inject constructor(
+    private val restManager: RestTimerProvider,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<Rest>(Rest.Default())
@@ -236,7 +236,7 @@ class RestTimerViewModel(
                 (_uiState.value as? Rest.Default)?.pickerValue?.parseMinuteTimeToMillis() ?: 0
             )
         } catch (_: IllegalArgumentException) {
-            toastManager.showToast(R.string.invalid_time_format)
+            /* TODO( add snackbar with R.string.invalid_time_format ) */
         }
     }
 


### PR DESCRIPTION
Migrate rest timer vm to hilt
Removed toast manager because currently it doesn't work with hilt ( we will remove toast manager and switch to snackbar )