### PR TITLE
[SPIKE] Roboelectric screenshot tests 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.android.build.api.dsl.ManagedVirtualDevice
-
 plugins {
     alias(libs.plugins.googleServices)
     alias(libs.plugins.kotlinSerialization)
@@ -9,11 +7,14 @@ plugins {
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
     alias(libs.plugins.baselineprofile)
+    alias(libs.plugins.screenshot)
+    alias(libs.plugins.roborazzi)
 }
 
 android {
     namespace = "bg.zahov.fitness.app"
     compileSdk = 35
+    experimentalProperties["android.experimental.enableScreenshotTest"] = true
 
     buildFeatures {
         compose = true
@@ -61,6 +62,13 @@ android {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
+        packagingOptions.resources.excludes.add("META-INF/versions/9/OSGI-INF/MANIFEST.MF")
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
     }
 }
 
@@ -81,7 +89,6 @@ dependencies {
     implementation(libs.navigationCompose)
     implementation(libs.material)
     implementation(libs.ui)
-    debugImplementation(libs.uiTooling)
     implementation(libs.uiToolingPreview)
     implementation(libs.material3)
     implementation(libs.activityCompose)
@@ -104,4 +111,8 @@ dependencies {
     implementation(libs.hiltNavigation)
     ksp(libs.hiltCompiler)
     implementation(libs.hiltTesting)
+    implementation(libs.roboelectric)
+    screenshotTestImplementation(libs.uiTooling)
+    testImplementation(libs.roborazzi)
+    testImplementation(libs.roborazziCompose)
 }

--- a/app/src/test/java/com/example/app/RoboScreenshotTest.kt
+++ b/app/src/test/java/com/example/app/RoboScreenshotTest.kt
@@ -1,0 +1,44 @@
+package com.example.app
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import bg.zahov.app.MainActivity
+import com.github.takahirom.roborazzi.captureRoboImage
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class RoboScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Before
+    fun setup() {
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun screenshotWelcomeScreen() {
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Test
+    fun screenshotLoginScreen() {
+        composeTestRule.onNodeWithText("Login").performClick()
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Test
+    fun screenshotSignupScreen() {
+        composeTestRule.onNodeWithText("Sign up").performClick()
+        composeTestRule.onNodeWithText("Username").captureRoboImage()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,8 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 org.gradle.configuration-cache=true
+android.experimental.enableScreenshotTest=true
+roborazzi.test.record=true
+roborazzi.test.compare=true
+roborazzi.test.verify=true
+testOptions.unitTests.includeAndroidResources = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ firebaseFunctions = "21.1.0"
 firebaseAuth = "23.1.0"
 firebaseFirestore = "25.1.1"
 junit = "4.13.2"
-espresso = "3.5.0"
+espresso = "3.6.1"
 coroutines = "1.8.0"
 mpChart = "v3.1.0"
 calendarCompose = "2.6.0"
@@ -19,8 +19,8 @@ androidPlugin = "7.4.2"
 serialization = "2.1.0"
 kotlinSerialization = "1.7.3"
 googleServicesPlugin = "4.4.2"
-androidxTestExtJunit = "1.1.5"
-androidxTestRunner = "1.5.0"
+androidxTestExtJunit = "1.2.1"
+androidxTestRunner = "1.6.2"
 material = "1.12.0"
 splashscreenVer = "1.0.1"
 numberPickerVer = "1.0.3"
@@ -31,6 +31,9 @@ uiautomator = "2.3.0"
 benchmarkMacroJunit4 = "1.3.3"
 baselineprofile = "1.3.3"
 profileinstaller = "1.4.1"
+roboelectric = "4.14"
+screenshot = "0.0.1-alpha09"
+roborazzi = "1.44.0-alpha01"
 
 [libraries]
 androidx-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
@@ -63,6 +66,9 @@ junit = { module = "junit:junit", version.ref = "junit" }
 espressoCore = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 androidxTestExtJunit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExtJunit" }
 androidxTestRunner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
+roboelectric = { module = "org.robolectric:robolectric", version.ref = "roboelectric" }
+roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version.ref = "roborazzi" }
+roborazziCompose = { module = "io.github.takahirom.roborazzi:roborazzi-compose", version.ref = "roborazzi" }
 
 firebaseFunctions = { module = "com.google.firebase:firebase-functions-ktx", version.ref = "firebaseFunctions" }
 firebaseAuth = { module = "com.google.firebase:firebase-auth-ktx", version.ref = "firebaseAuth" }
@@ -87,3 +93,5 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "kspVer" }
 android-test = { id = "com.android.test", version.ref = "androidPlugin" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
 android-library = { id = "com.android.library", version.ref = "androidPlugin" }
+screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot" }
+roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }


### PR DESCRIPTION
### Screenshot testing with roboelectric

Roboelectric only has support for screenshots -> _Note: Robolectric can take screenshots natively, but you need a third-party library to perform screenshot testing with it._  [here](https://developer.android.com/training/testing/local-tests/robolectric).

Luckily there is a library that is consistently maintained and adapted specifically for roboelectric screenshot tests -> [https://github.com/takahirom/roborazzi](url)

Compared to the native option for screenshot tests there really isn't that much difference. Both are very straightforward however what I noticed is that since the "golden" images and the results from the test are stored in the build folder unless we manually designate a space for them and move them out every time everyone would need to generate images before they touch anything related to the ui as otherwise the tests will always succeed.

The advantage of using roboelectric for screenshot testing is roboelectric itself 😅. We can set up a test environment where we simulate lack of data and see how the ui responds.

Here is the result of a test I failed on purpose(simply changed some paddings):
![image](https://github.com/user-attachments/assets/88d370ce-0c03-486a-9e6a-0e35cd8bf9ce)

Overall I think for the specific purpose of screenshot testing the native option is much better. It forces us to make previews for our composables and the process seems to be clearer
