### PR TITLE
[SPIKE] Paparazzi screenshot tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.baselineprofile)
     alias(libs.plugins.screenshot)
     alias(libs.plugins.roborazzi)
+    alias(libs.plugins.paparazzi)
 }
 
 android {
@@ -115,4 +116,5 @@ dependencies {
     screenshotTestImplementation(libs.uiTooling)
     testImplementation(libs.roborazzi)
     testImplementation(libs.roborazziCompose)
+    testImplementation(libs.paparazzi)
 }

--- a/app/src/test/java/com/example/app/PaparazziScreenshotTest.kt
+++ b/app/src/test/java/com/example/app/PaparazziScreenshotTest.kt
@@ -1,0 +1,54 @@
+package com.example.app
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import bg.zahov.app.ui.authentication.login.LoginContent
+import bg.zahov.app.ui.authentication.signup.SignupContent
+import org.junit.Rule
+import org.junit.Test
+
+class PaparazziScreenshotTest {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5
+    )
+
+    @Test
+    fun loginScreen(){
+        paparazzi.snapshot {
+            LoginContent(
+                email = "",
+                onEmailChange = {},
+                password = "",
+                onPasswordChange = {},
+                passwordVisibility = false,
+                onPasswordVisibilityChange = {},
+                navigateSignUp = {},
+                logIn = {},
+                resetPassword = {}
+            )
+        }
+    }
+
+    @Test
+    fun signInTest() {
+        paparazzi.snapshot {
+            SignupContent(
+                username = "",
+                email = "",
+                password = "",
+                showPassword = false,
+                confirmPassword = "",
+                onNameChange = {},
+                onEmailChange = {},
+                onPasswordChange = {},
+                onConfirmPasswordChange = {},
+                onSignupButtonPressed = {},
+                onPasswordVisibilityChange = {},
+                onNavigateToLogin = {}
+            )
+        }
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ profileinstaller = "1.4.1"
 roboelectric = "4.14"
 screenshot = "0.0.1-alpha09"
 roborazzi = "1.44.0-alpha01"
+paparazzi = "1.3.5"
 
 [libraries]
 androidx-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
@@ -81,6 +82,8 @@ numberPicker = { module = "com.chargemap.compose:numberpicker", version.ref = "n
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "benchmarkMacroJunit4" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
+paparazzi = { group = "app.cash.paparazzi",name = "paparazzi", version.ref = "paparazzi" }
+
 
 [plugins]
 googleServices = { id = "com.google.gms.google-services", version.ref = "googleServicesPlugin" }
@@ -95,3 +98,4 @@ baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprof
 android-library = { id = "com.android.library", version.ref = "androidPlugin" }
 screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot" }
 roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }
+paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }


### PR DESCRIPTION
Screenshot testing with paparazzi

Paparazzi is a JVM-based screenshot testing library that lets you render your Android UI and compare it to golden images —without launching an emulator or connecting a device. It's very easy to set up and provides support to views and compose. 

To make a screenshot test , you have to provide it with ONLY the screen content (no viewmodels ). The screen needs to support the @Preview  annotation in Android Studio for it to work. For the test there are a set of screen configurations to choose from like Pixel 2-5 and ect. , but that's the limitation.  The cool thing is that it can have a record of screenshots throughout different versions and there is a generated html file that allows you to look at them with ease:

![image](https://github.com/user-attachments/assets/4e1e8387-a9cf-4c4c-943c-202c243d9bdd)

Additionally we can setup a Git LFS to store there the images. 

And here is a failed test between the golden image and image with removed button.
 
![delta-com example app_PaparazziScreenTest_testingLoginScreen](https://github.com/user-attachments/assets/da139903-64b0-450a-aaf9-b43ad8e04ee7)

The lib seems fairly maintained but no regular updates.
